### PR TITLE
Fix taint tracking template hints

### DIFF
--- a/workshop-2021/README.md
+++ b/workshop-2021/README.md
@@ -383,12 +383,12 @@ class DubboUnsafeDeserializationConfig extends TaintTracking::Configuration {
     )
   }
   override predicate isSink(DataFlow::Node sink) {
-    exists(/** TODO fill me in **/ |
-      sink.asExpr() = /** TODO fill me in **/
-    )
+    /** TODO fill me in **/
   }
   override predicate isAdditionalTaintStep(DataFlow::Node n1, DataFlow::Node n2) {
+    exists(/** TODO fill me in **/ |
       /** TODO fill me in **/
+    )
   }
 }
 


### PR DESCRIPTION
Change the hints so that it more closely aligns with the final solution.

The sink does not use an `exists` clause and the `isAdditionalTaintStep` does.